### PR TITLE
Update bower config for new version of private bower

### DIFF
--- a/bowerConfig.json
+++ b/bowerConfig.json
@@ -2,8 +2,13 @@
     "port": 5678,
     "registryFile": "/data/bowerRepository.json",
     "timeout": 144000,
-    "disablePublic": false,
-    "publicRegistry": "http://bower.herokuapp.com/packages/",
+    "public": {
+        "disabled": false,
+        "registry": "http://bower.herokuapp.com/packages/",
+        "registryFile": "/data/bowerRepositoryPublic.json",
+        "whitelist": [],
+        "blacklist": []
+    },
     "authentication": {
         "enabled": false,
         "key": "password"


### PR DESCRIPTION
private-bower has released the 1.0 version where the config format has changed a bit.

See https://github.com/Hacklone/private-bower/commit/5438a0ae4ff100cfb9a15cc13f7630893f7f1f8a
