### PR TITLE
Fix permissions for launch.sh and ssh keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,12 @@ VOLUME /data
 WORKDIR /home/private-bower
 
 ADD ./bowerConfig.json /home/private-bower/bowerConfig.json
-ADD ./launch.sh /home/private-bower/launch.sh
-ADD ./ssh/ /root/.ssh
 
+ADD ./launch.sh /home/private-bower/launch.sh
+RUN chmod +x /home/private-bower/launch.sh
+
+ADD ./ssh/ /root/.ssh
+RUN chmod 600 /root/.ssh/*
 
 # Work around company firewalls blocking the git protocol
 RUN git config --global url."https://github.com/".insteadOf "git://github.com/"


### PR DESCRIPTION
Hello @tandrup, 

I had issues running your docker instance on AWS ECS standard machine, basically launch.sh was not accessible and also later the ssh keys. 

The following changes shall fix this in the cases it happen, also shall not affect the already working cases. 

All the best!
Felipe